### PR TITLE
added option for socket timeout

### DIFF
--- a/lib/driver/tcp.js
+++ b/lib/driver/tcp.js
@@ -33,8 +33,14 @@ Driver.connect = function (port, host, options) {
 				return next(null, new stream(transport(socket), options));
 			});
 
-			socket.on("error", onError);
-
+			if (options.timeout) {
+				let timeOut = Math.min(60000,Math.max(1000,parseInt(options.timeout)));
+				socket.setTimeout(timeOut);
+				socket.on('timeout', () => {
+					socket.end();
+				});
+			}
+			
 			return socket;
 		}
 	};


### PR DESCRIPTION
If the {timeout:3000} is present it will be limited to 1000 to 60000.
Can be either a number or string {timeout:'3000'}.